### PR TITLE
fix: use layonara user for hak build CI

### DIFF
--- a/.github/workflows/nwsync-build.yml
+++ b/.github/workflows/nwsync-build.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: SSH to leanthar - build haks and stage to ee64-new
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.LEANTHAR_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          echo "${{ secrets.LEANTHAR_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          ssh -o BatchMode=yes root@5.161.122.37 '/opt/layonara/nwsync-builder/build.sh && /opt/layonara/nwsync-builder/stage-haks.sh'
+      - name: Build haks and stage to ee64
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LEANTHAR_HOST }}
+          username: layonara
+          key: ${{ secrets.LEANTHAR_SSH_KEY }}
+          command_timeout: 25m
+          script: |
+            /opt/layonara/nwsync-builder/build.sh && /opt/layonara/nwsync-builder/stage-haks.sh


### PR DESCRIPTION
Switch from root SSH with manual key to layonara user via appleboy/ssh-action, matching the module deploy pattern.